### PR TITLE
LIBWHCA-271. Simplify header string decoding.

### DIFF
--- a/src/processing/common/load_mbox_data.py
+++ b/src/processing/common/load_mbox_data.py
@@ -1,14 +1,12 @@
 import hashlib
 import logging
 import mailbox
-import os
 import re
-import requests
-
-from bs4 import BeautifulSoup
-from email.header import decode_header
+from email.header import decode_header, make_header
 from email.utils import parsedate_to_datetime
 
+import requests
+from bs4 import BeautifulSoup
 from django.core.files.base import ContentFile
 
 from processing.models import Batch, File, Item
@@ -138,6 +136,10 @@ def is_pool_report(html: str) -> bool:
     return True
 
 
+def decode_header_string(header: str) -> str:
+    return str(make_header(decode_header(header)))
+
+
 def load_data(file_path, batch_id):
     batch = Batch(id=batch_id)
     logger.debug(f'Batch ID: {batch_id}')
@@ -152,17 +154,11 @@ def load_data(file_path, batch_id):
         logger.debug(date)
 
         # Reporter
-        From, encoding = decode_header(message['From'])[0]
-        if isinstance(From, bytes):
-            From = From.decode(encoding)
-        item.reporter = process_reporter(From)
+        item.reporter = process_reporter(decode_header_string(message['From']))
         logger.debug(item.reporter)
 
         # Title
-        subject, encoding = decode_header(message['Subject'])[0]
-        if isinstance(subject, bytes):
-            subject = subject.decode(encoding)
-        item.title = scrub_title(subject)
+        item.title = scrub_title(decode_header_string(message['Subject']))
         logger.debug(item.title)
 
         # Body

--- a/tests/test_load_mbox_data.py
+++ b/tests/test_load_mbox_data.py
@@ -1,6 +1,7 @@
 import pytest
 
-from src.processing.common.load_mbox_data import is_pool_report, process_reporter, scrub_title, scrub_body
+from src.processing.common.load_mbox_data import is_pool_report, process_reporter, scrub_title, scrub_body, \
+    decode_header_string
 
 
 @pytest.mark.parametrize(
@@ -101,3 +102,14 @@ NONPOOL_REPORT_EXAMPLES = [
     We are writing ...
     '''
 ]
+
+
+@pytest.mark.parametrize(
+    ('raw_header_string', 'expected_string'),
+    [
+        ('Simple', 'Simple'),
+        ('Advertising Request =?utf-8?Q?for=C2=A0whca=2Epress?=', 'Advertising Request for\xa0whca.press'),
+    ]
+)
+def test_decode_header_string(raw_header_string, expected_string):
+    assert decode_header_string(raw_header_string) == expected_string


### PR DESCRIPTION
Use Python's own make_header() function to reconstruct the decoded header parts into a single string without the encoding tags.

https://umd-dit.atlassian.net/browse/LIBWHCA-271