### PR TITLE
LIBWHCA-276. Improve local development environment setup

### DIFF
--- a/docs/DevelopmentEnvironment.md
+++ b/docs/DevelopmentEnvironment.md
@@ -2,94 +2,140 @@
 
 ## Introduction
 
-This document provides guidance on setting up a Scutes development environment on a local workstation.
+This document provides guidance on setting up a Scutes development environment
+on a local workstation.
 
 ## Prerequisites
 
-The following instructions assume that "pyenv" is installed to enable
-the setup of an isolated Python environment.
+* Python 3.11
 
-See the following for setup instructions:
+* Install `libxmlsec1`. This is required for SAML authentication using
+  [djangosaml2].
 
-* <https://github.com/pyenv/pyenv>
+  On macOS, it is available via Homebrew:
 
-Once "pyenv" have been installed, install Python 3.11:
+  ```zsh
+  brew install xmlsec1
+  ```
 
-```zsh
-pyenv install 3.11
-```
+  On Debian or Ubuntu Linux, it is available via `apt`:
 
-This should download and install that version of Python.
+  ```zsh
+  sudo apt-get install xmlsec1
+  ```
 
-## Setup
+* Update the `/etc/hosts` file to add:
 
-Clone Scutes from GitHub:
+  ```zsh
+  127.0.0.1 scutes-local
+  ```
 
-```bash
-git clone git@github.com:umd-lib/scutes
-cd scutes
-python -m venv --prompt "scutes-py$(cat .python-version)" .venv
-source .venv/bin/activate
-pip install -e .
-```
+* Scutes uses UMD SSO with Grouper for authorization.
 
-Install `libxmlsec1`. This is required for the SAML authentication using
-[djangosaml2].
+  You must be a member of either the `Scutes-Administrator` or `Scutes-User`
+  Grouper group to log in, even when running in the local development
+  environment.
 
-On Mac, it is available via Homebrew:
+## Application Setup
 
-```bash
-brew install xmlsec1
-```
+1) Clone Scutes from GitHub:
 
-On Debian or Ubuntu Linux, it is available via `apt`:
+    ```zsh
+    git clone git@github.com:umd-lib/scutes
+    cd scutes
+    ```
 
-```bash
-sudo apt-get install xmlsec1
-```
+2) Set up the Python virtual environment, and install the dependencies
 
-Update the `/etc/hosts` file to add:
+    ```zsh
+    python -m venv --prompt "scutes-py$(cat .python-version)" .venv
+    source .venv/bin/activate
+    pip install -e .
+    ```
 
-```
-127.0.0.1   localhost scutes-local
-```
+3) Download the `scutes-test-lib-umd-edu-sp.key` and
+  `scutes-test-lib-umd-edu-sp.crt` files from the  "scutes-local-saml" entry in
+   LastPass into the "scutes" project root directory.
 
-Add key and crt files to src/scutes directory.
+    ℹ️ Note: These files can be placed in a directory outside the project,
+    if desired. Also, when downloading the `scutes-test-lib-umd-edu-sp.crt`
+    file, Google Chrome will modify the file extension, by default, to ".cer".
+    Be sure to specify the ".crt" extension when downloading the file.
+    Mozilla Firefox preserves the ".crt" extension.
 
-Setup env file.
-Copy/rename ```src/.env-dev-example``` to ```src/.env``` and make adjustments as necessary.
+4) Copy the `src/.env-dev-example` file to `src/.env`:
 
-## Initalize the database
+    ```zsh
+    cp src/.env-dev-example src/.env
+    ```
 
-In src directory, run migrate command:
+    and update the following variables with the appropriate values as needed.
 
-```zsh
-./manage.py migrate
-```
+    Relative directories (where used) are resolved from the directory where the
+    `manage.py` script is run. The following examples assume `manage.py` is run
+    from the project root as `src/manage.py` (so relative paths are relative to
+    the project root):
 
-Import Data
+    * `KEY_FILE` - relative (or absolute) file path to the
+      `scutes-test-lib-umd-edu-sp.key` file
+
+      Default in example file assumes key is in the project root:
+      `'scutes-test-lib-umd-edu-sp.key'`
+
+    * `CERT_FILE` - relative (or absolute) file path to the
+      `scutes-test-lib-umd-edu-sp.crt` file
+
+      Default in example file assumes cert is in the project root:
+      `'scutes-test-lib-umd-edu-sp.crt'`
+
+    * `MEDIA_ROOT` - relative (or absolute) file path to where user-uploaded
+      files are saved.
+
+      Default in example file is `'src/media/'`
+
+    * `SECRET_KEY` - An (insecure) key is provided by default, which should
+      **not** be used for production systems. For production, a source of
+      sufficient randomness, such as `uuidgen | shasum -a 256 | cut -c-64`
+      should be used to generate the key.
+
+    * `WHITENOISE_ROOT` - relative (or absolute) file path to directory
+      containing static files served by the "WhiteNoise" server
+
+      Default in example file is `'src/static/'`
+
+    * `XMLSEC1_PATH` - The full file path to the "xmlsec1" binary, (usually
+      findable by running `which xmlsec1`).
+
+      Default in example file assumes Homebrew install:
+      `/opt/homebrew/bin/xmlsec1`
+
+5) Initialize the database, using the `migrate` command:
+
+    ```zsh
+    src/manage.py migrate
+    ```
+
+6) Import Data
+
     Use either YAML test data or an .mbox file
     See Management Commands
 
-## Start the dev server
+7) Start the dev server
 
-```zsh
-./manage.py runserver
-```
+    ```zsh
+    src/manage.py runserver
+    ```
 
-The application will be running at <http://scutes-local:15000/>
+    The application will be running at <http://scutes-local:15000/>
 
-### Note: Use ctrl+c to stop the server
+    **Note:** Use ctrl+c to stop the server
 
-If the prompt is given back without stopping the server, you will need to kill the process
+    If the prompt is given back without stopping the server, you will need to
+    kill the process:
 
-```zsh
-lsof -t -i tcp:15000 | xargs kill -9
-```
-
-### Note: Scutes uses SSO
-
-Scutes uses UMD SSO. You will need to be added to the appropriate Grouper group in order to use the web interface.
+    ```zsh
+    lsof -t -i tcp:15000 | xargs kill -9
+    ```
 
 ### Tests
 
@@ -111,3 +157,7 @@ To run with coverage information:
 ```zsh
 pytest --cov src --cov-report term-missing
 ```
+
+[djangosaml2]: https://djangosaml2.readthedocs.io/
+[pytest]: https://pytest.org/
+[pytest-django]: https://pytest-django.readthedocs.io/en/latest/

--- a/src/.env-dev-example
+++ b/src/.env-dev-example
@@ -12,7 +12,7 @@ SERVER_HOST='scutes-local'
 SERVER_PORT='15000'
 
 # whitenoise
-WHITENOISE_ROOT='/path/to/static'
+WHITENOISE_ROOT='src/static/'
 
 # session logout
 IDLE_TIME=1440000
@@ -25,9 +25,9 @@ XMLSEC_BINARY='/opt/homebrew/bin/xmlsec1'
 ENTITYID='scutes-local:15000'
 ENDPOINT_ADDRESS='http://scutes-local:15000'
 
-# Full path to key and crt
-KEY_FILE='/path/to/scutes-test-lib-umd-edu-sp.key'
-CERT_FILE='/path/to/scutes-test-lib-umd-edu-sp.crt'
+# Relative or full path to key and crt
+KEY_FILE='scutes-test-lib-umd-edu-sp.key'
+CERT_FILE='scutes-test-lib-umd-edu-sp.crt'
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY='django-insecure-l@#aomb8&s8-ut6b23y18l2t!khm@p+s4bxc5)oh71pp%+b(0k'
@@ -54,5 +54,5 @@ STATIC_ROOT=BASE_DIR / 'static'
 
 # Media
 MEDIA_URL='/media/'
-MEDIA_ROOT='exact/path/as/a/string'  # Example: '/Users/username/scutes/src/media'
+MEDIA_ROOT='src/media/'  # Example: '/Users/username/scutes/src/media'
 # Another option for MEDIA_ROOT is https://docs.python.org/3/library/os.path.html#os.path.expandvars


### PR DESCRIPTION
Improved the local development environment setup by:

* Modifying “docs/DevelopmentEnvironment.md”, to make steps more consistent with other Python projects, largely using Grove as a model, by explicitly numbering steps, and consolidating prerequisites

* Updated application start instructions to assume running from project root, instead of the “src” directory, as that is more consistent with other Python projects.

* In “src/.env-dev-example”, added suitable defaults assuming a MacOS laptop with the SAML key and certificate installed in the project root, and setting “WHITENOISE_ROOT” and “MEDIA_ROOT” to existing directories within Scutes:

  * CERT_FILE='../scutes-test-lib-umd-edu-sp.crt'
  * KEY_FILE='../scutes-test-lib-umd-edu-sp.key'
  * MEDIA_ROOT='src/media/'
  * WHITENOISE_ROOT='src/static/'

* Updated “docs/DevelopmentEnvironment.md” with information about commonly modified environment variables and their defaults in “src/.env-dev-example”

https://umd-dit.atlassian.net/browse/LIBWHCA-276